### PR TITLE
octane authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.12.1|^1.13.9|^1.14.0",
-        "laravel/framework": "^8.37|^9.0|^v10.48.*",
+        "laravel/framework": "^8.37|^9.0|^v10.48",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "nunomaduro/larastan": "^2.9",
         "laravel/octane": "^1.4",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "1.*|^2.34",
+        "pestphp/pest": "^1.*|^2.34",
         "pestphp/pest-plugin-arch": "^1.*|^2.7",
         "pestphp/pest-plugin-laravel": "^v1.4.0|^2.4",
         "phpstan/extension-installer": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "nunomaduro/larastan": "^2.9",
         "laravel/octane": "^1.4",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^1.*|^2.34",
+        "pestphp/pest": "^1.22|^2.34",
         "pestphp/pest-plugin-arch": "^1.*|^2.7",
         "pestphp/pest-plugin-laravel": "^v1.4.0|^2.4",
         "phpstan/extension-installer": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.12.1|^1.13.9|^1.14.0",
-        "laravel/framework": "^8.37|^9.0|^v10.48.9",
+        "laravel/framework": "^8.37|^9.0|^v10.48.*",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
@@ -28,7 +28,7 @@
         "nunomaduro/larastan": "^2.9",
         "laravel/octane": "^1.4",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "1.22|^2.34",
+        "pestphp/pest": "^1.22|^2.34",
         "pestphp/pest-plugin-arch": "^2.7",
         "pestphp/pest-plugin-laravel": "^v1.4.0|^2.4",
         "phpstan/extension-installer": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.12.1|^1.13.9|^1.14.0",
-        "laravel/framework": "^8.37|^9.0|^10.0",
+        "laravel/framework": "^8.37|^9.0|^v10.48.9",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "laravel/octane": "^1.4",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "1.*|^2.34",
-        "pestphp/pest-plugin-arch": "^2.7",
+        "pestphp/pest-plugin-arch": "^1.*|^2.7",
         "pestphp/pest-plugin-laravel": "^v1.4.0|^2.4",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "^2.34",
         "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3",
+        "pestphp/pest-plugin-laravel": "^2.3|^2.4",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "nunomaduro/larastan": "^2.9",
         "laravel/octane": "^1.4",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^1.22|^2.34",
+        "pestphp/pest": "1.22|^2.34",
         "pestphp/pest-plugin-arch": "^1.*|^2.7",
         "pestphp/pest-plugin-laravel": "^v1.4.0|^2.4",
         "phpstan/extension-installer": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "^2.34",
         "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3|^2.4",
+        "pestphp/pest-plugin-laravel": "^v1.4.0|^2.4",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "nunomaduro/larastan": "^2.9",
         "laravel/octane": "^1.4",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^2.34",
+        "pestphp/pest": "1.*|^2.34",
         "pestphp/pest-plugin-arch": "^2.7",
         "pestphp/pest-plugin-laravel": "^v1.4.0|^2.4",
         "phpstan/extension-installer": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -23,17 +23,17 @@
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9",
-        "nunomaduro/larastan": "^2.0.1",
+        "laravel/pint": "^1.14",
+        "nunomaduro/collision": "^7.9|8.1.1",
+        "nunomaduro/larastan": "^2.9",
         "laravel/octane": "^1.4",
-        "orchestra/testbench": "^8.0",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "pestphp/pest": "^2.34",
+        "pestphp/pest-plugin-arch": "^2.7",
+        "pestphp/pest-plugin-laravel": "^2.3",
+        "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan-deprecation-rules": "^1.1",
+        "phpstan/phpstan-phpunit": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "laravel/octane": "^1.4",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "1.22|^2.34",
-        "pestphp/pest-plugin-arch": "^1.*|^2.7",
+        "pestphp/pest-plugin-arch": "^2.7",
         "pestphp/pest-plugin-laravel": "^v1.4.0|^2.4",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1",

--- a/src/Listeners/Octane/RequestReceived.php
+++ b/src/Listeners/Octane/RequestReceived.php
@@ -66,7 +66,7 @@ class RequestReceived
                 auth()->authenticate();
                 $user = auth()->user();
             } catch (\Exception $exception) {
-                Log::channel(config('laravel-request-tracker.log_channel'))->error('user can\'t authenticate ', [
+                Log::channel(config('laravel-request-tracker.log_channel'))->error($exception->getMessage(), [
                     'message' => $exception->getMessage(),
                     'file' => $exception->getFile(),
                     'line' => $exception->getLine(),

--- a/src/Listeners/Octane/RequestReceived.php
+++ b/src/Listeners/Octane/RequestReceived.php
@@ -9,8 +9,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Octane\Events\RequestReceived as OctaneRequestReceived;
 
-use function config;
-
 class RequestReceived
 {
     private string $trackerId;


### PR DESCRIPTION
- require laravel v 8|9|10 and php ^8.0
- require laravel v 8|9|10 and php ^8.0
- handle composer file
- WIP
- Fix styling
- handle readme
- Update run-tests.yml
- handle http called
- Fix styling
- reset configs
- support l 8
- support l 8
- handle missed started
- Fix styling
- handle not started
- fix test
- Replaced classes with qualifiers and update docs
- Bump dependabot/fetch-metadata from 1.3.6 to 1.4.0
- support laravel octane
- Fix styling
- remove func from import
- handle events
- Fix styling
- Bump dependabot/fetch-metadata from 1.4.0 to 1.5.1
- Bump aglipanci/laravel-pint-action from 2.2.0 to 2.3.0
- Bump dependabot/fetch-metadata from 1.5.1 to 1.6.0
- handle log channel
- Fix styling
- handle custome log for octane
- Fix styling
- handle athenticate user
- Fix styling
- remove funtion
- config
